### PR TITLE
[fix]: createPoolWithFirstBuy, createConfigAndPoolWithFirstBuy and getPoolBaseTokenCurveProgress endpoints

### DIFF
--- a/packages/dynamic-bonding-curve/CHANGELOG.md
+++ b/packages/dynamic-bonding-curve/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the Dynamic Bonding Curve SDK will be documented in this 
 - Fixed `getBaseTokenForSwap` function to correctly calculate the base token for swap
 - `createPoolWithFirstBuy` functions now return a `Transaction` instead of an object containing the new config transaction and pool transaction
 - `createConfigAndPoolWithFirstBuy` functions now return `createConfigTx` and `createPoolWithFirstBuyTx` as separate `Transaction` instead of an object containing 3 separate transactions
+- `createPoolWithPartnerAndCreatorFirstBuy` functions now return a `Transaction` instead of an object containing the new config transaction and pool transaction
 
 ## [1.5.4] - 2026-02-24
 

--- a/packages/dynamic-bonding-curve/CHANGELOG.md
+++ b/packages/dynamic-bonding-curve/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Dynamic Bonding Curve SDK will be documented in this file.
 
+## [1.5.5] - 2026-02-25
+
+### Changed
+
+- Fixed `getBaseTokenForSwap` function to correctly calculate the base token for swap
+- `createPoolWithFirstBuy` functions now return a `Transaction` instead of an object containing the new config transaction and pool transaction
+- `createConfigAndPoolWithFirstBuy` functions now return `createConfigTx` and `createPoolWithFirstBuyTx` as separate `Transaction` instead of an object containing 3 separate transactions
+
 ## [1.5.4] - 2026-02-24
 
 ### Added

--- a/packages/dynamic-bonding-curve/CHANGELOG.md
+++ b/packages/dynamic-bonding-curve/CHANGELOG.md
@@ -6,9 +6,9 @@ All notable changes to the Dynamic Bonding Curve SDK will be documented in this 
 
 ### Changed
 
-- Fixed `getBaseTokenForSwap` function to correctly calculate the base token for swap
+- Fixed `getPoolBaseTokenCurveProgress` function to correctly calculate the progress of the base token curve using `getBaseTokenForSwap` function
+- `createConfigAndPoolWithFirstBuy` functions now return `createConfigTx` and `createPoolWithFirstBuyTx` as separate `Transaction` instead of an object containing 3 separate `Transaction`s
 - `createPoolWithFirstBuy` functions now return a `Transaction` instead of an object containing the new config transaction and pool transaction
-- `createConfigAndPoolWithFirstBuy` functions now return `createConfigTx` and `createPoolWithFirstBuyTx` as separate `Transaction` instead of an object containing 3 separate transactions
 - `createPoolWithPartnerAndCreatorFirstBuy` functions now return a `Transaction` instead of an object containing the new config transaction and pool transaction
 
 ## [1.5.4] - 2026-02-24

--- a/packages/dynamic-bonding-curve/docs.md
+++ b/packages/dynamic-bonding-curve/docs.md
@@ -1858,7 +1858,7 @@ const transaction = await client.pool.createConfigAndPool({
 
 ### createConfigAndPoolWithFirstBuy
 
-Creates a config key and a token pool and buys the token immediately in a single transaction.
+Creates a config key and a token pool and buys the token immediately.
 
 **Function**
 
@@ -1866,7 +1866,6 @@ Creates a config key and a token pool and buys the token immediately in a single
 async createConfigAndPoolWithFirstBuy(params: CreateConfigAndPoolWithFirstBuyParams): Promise<{
     createConfigTx: Transaction
     createPoolTx: Transaction
-    swapBuyTx: Transaction | undefined
 }>
 ```
 
@@ -1986,14 +1985,16 @@ interface CreateConfigAndPoolWithFirstBuyParams {
 
 **Returns**
 
-An object of transactions (containing createConfigTx, createPoolTx, and swapBuyTx) that requires signatures before being submitted to the network. Can be bundled together.
+An object of transactions containing:
+- `createConfigTx`: config creation transaction
+- `createPoolTx`: pool creation transaction, with first-buy instructions included when `firstBuyParam` is provided and `buyAmount > 0`
 
 **Example**
 
 ```typescript
 const amountIn = await prepareSwapAmountParam(1, NATIVE_MINT, connection)
 
-const transaction = await client.pool.createConfigAndPoolWithFirstBuy({
+const transactions = await client.pool.createConfigAndPoolWithFirstBuy({
     payer: new PublicKey('boss1234567890abcdefghijklmnopqrstuvwxyz'),
     config: new PublicKey('1234567890abcdefghijklmnopqrstuvwxyz'),
     feeClaimer: new PublicKey('boss1234567890abcdefghijklmnopqrstuvwxyz'),
@@ -2102,9 +2103,8 @@ const transaction = await client.pool.createConfigAndPoolWithFirstBuy({
 
 - The payer must be the same as the payer in the `CreateConfigAndPoolWithFirstBuyParam` params.
 - The `createConfigTx` requires the payer and config to sign the transaction.
-- The `createPoolTx` requires the payer, poolCreator, and baseMint to sign the transaction.
-- If the `firstBuyParam` is not provided, the `swapBuyTx` will be undefined.
-- The `swapBuyTx` requires the buyer and payer to sign the transaction.
+- The `createPoolTx` requires the payer, poolCreator, and baseMint to sign the transaction. If `firstBuyParam` is provided, it also requires buyer/payer signatures for the appended first-buy instructions.
+- If the `firstBuyParam` is not provided, `createPoolTx` includes only pool-creation instructions.
 - The `receiver` parameter is an optional account. If provided, the token will be sent to the receiver address.
 
 ---
@@ -2118,7 +2118,6 @@ Creates a new pool with the config key and buys the token immediately.
 ```typescript
 async createPoolWithFirstBuy(params: CreatePoolWithFirstBuyParams): Promise<{
     createPoolTx: Transaction
-    swapBuyTx: Transaction | undefined
 }>
 ```
 
@@ -2148,7 +2147,7 @@ interface CreatePoolWithFirstBuyParams {
 
 **Returns**
 
-An object of transactions (containing createPoolTx and swapBuyTx) that requires signatures before being submitted to the network. Can be bundled together.
+An object containing `createPoolTx`, where first-buy instructions are included when `firstBuyParam` is provided and `buyAmount > 0`.
 
 **Example**
 
@@ -2177,7 +2176,7 @@ const transaction = await client.pool.createPoolWithFirstBuy({
 **Notes**
 
 - The `poolCreator` is required to sign when creating the pool.
-- The `buyer` is required to sign when buying the token.
+- The `buyer` is required to sign when `firstBuyParam` is provided.
 - The `baseMint` token type must be the same as the config key's token type.
 - The `minimumAmountOut` parameter protects against slippage. Set it to a value slightly lower than the expected output.
 - The `referralTokenAccount` parameter is an optional token account. If provided, the referral fee will be applied to the transaction.

--- a/packages/dynamic-bonding-curve/docs.md
+++ b/packages/dynamic-bonding-curve/docs.md
@@ -2192,11 +2192,7 @@ Creates a new pool with the config key and buys the token immediately with partn
 **Function**
 
 ```typescript
-async createPoolWithPartnerAndCreatorFirstBuy(params: CreatePoolWithPartnerAndCreatorFirstBuyParams): Promise<{
-    createPoolTx: Transaction
-    partnerSwapBuyTx: Transaction | undefined
-    creatorSwapBuyTx: Transaction | undefined
-}>
+async createPoolWithPartnerAndCreatorFirstBuy(params: CreatePoolWithPartnerAndCreatorFirstBuyParams): Promise<Transaction>
 ```
 
 **Parameters**
@@ -2233,7 +2229,7 @@ interface CreatePoolWithPartnerAndCreatorFirstBuyParams {
 
 **Returns**
 
-An object of transactions (containing createPoolTx, partnerSwapBuyTx, and creatorSwapBuyTx) that requires signatures before being submitted to the network. Can be bundled together.
+A single transaction containing pool creation and optional partner/creator first buy instructions. Partner and creator swap instructions are appended when their corresponding params are provided with `buyAmount > 0`.
 
 **Example**
 
@@ -2279,8 +2275,8 @@ const transaction = await client.pool.createPoolWithPartnerAndCreatorFirstBuy({
 **Notes**
 
 - The `poolCreator` is required to sign when creating the pool.
-- The `partner` is required to sign when buying the token.
-- The `creator` is required to sign when buying the token.
+- The `partner` is required to sign when `partnerFirstBuyParam` is provided with `buyAmount > 0`.
+- The `creator` is required to sign when `creatorFirstBuyParam` is provided with `buyAmount > 0`.
 - The `baseMint` token type must be the same as the config key's token type.
 - The `minimumAmountOut` parameter protects against slippage. Set it to a value slightly lower than the expected output.
 - The `referralTokenAccount` parameter is an optional token account. If provided, the referral fee will be applied to the transaction.

--- a/packages/dynamic-bonding-curve/docs.md
+++ b/packages/dynamic-bonding-curve/docs.md
@@ -1986,6 +1986,7 @@ interface CreateConfigAndPoolWithFirstBuyParams {
 **Returns**
 
 An object of transactions containing:
+
 - `createConfigTx`: config creation transaction
 - `createPoolTx`: pool creation transaction, with first-buy instructions included when `firstBuyParam` is provided and `buyAmount > 0`
 

--- a/packages/dynamic-bonding-curve/package.json
+++ b/packages/dynamic-bonding-curve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteora-ag/dynamic-bonding-curve-sdk",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "source": "src/index.ts",

--- a/packages/dynamic-bonding-curve/src/helpers/common.ts
+++ b/packages/dynamic-bonding-curve/src/helpers/common.ts
@@ -302,8 +302,8 @@ export function getBaseTokenForSwap(
 ): BN {
     let totalAmount = new BN(0)
     for (let i = 0; i < curve.length; i++) {
-        const lowerSqrtPrice = i == 0 ? sqrtStartPrice : curve[i - 1].sqrtPrice
-        if (curve[i].sqrtPrice && curve[i].sqrtPrice.gt(sqrtMigrationPrice)) {
+        const lowerSqrtPrice = i === 0 ? sqrtStartPrice : curve[i - 1].sqrtPrice
+        if (curve[i].sqrtPrice.gt(sqrtMigrationPrice)) {
             const deltaAmount = getDeltaAmountBaseUnsigned(
                 lowerSqrtPrice,
                 sqrtMigrationPrice,

--- a/packages/dynamic-bonding-curve/src/services/state.ts
+++ b/packages/dynamic-bonding-curve/src/services/state.ts
@@ -183,8 +183,6 @@ export class StateService extends DynamicBondingCurveProgram {
             ).toString()
         )
 
-        console.log('baseSold:', baseSold.toString())
-
         const totalBaseCouldBeSold = new Decimal(
             getBaseTokenForSwap(
                 config.sqrtStartPrice,
@@ -192,8 +190,6 @@ export class StateService extends DynamicBondingCurveProgram {
                 config.curve
             ).toString()
         )
-
-        console.log('totalBaseCouldBeSold:', totalBaseCouldBeSold.toString())
 
         const progress = baseSold.div(totalBaseCouldBeSold).toNumber()
 

--- a/packages/dynamic-bonding-curve/tests/first_swap.test.ts
+++ b/packages/dynamic-bonding-curve/tests/first_swap.test.ts
@@ -162,36 +162,27 @@ describe('First Swap Tests', { timeout: 60000 }, () => {
     test('should charge min fee when using SDK createPoolWithFirstBuy (bundled tx)', async () => {
         const amountIn = new BN(1_000_000_000) // 1 SOL
 
-        const { createPoolTx, swapBuyTx } =
-            await dbcClient.pool.createPoolWithFirstBuy({
-                createPoolParam: {
-                    baseMint: baseMint.publicKey,
-                    config: config.publicKey,
-                    name: 'TEST',
-                    symbol: 'TEST',
-                    uri: 'https://ipfs.io/ipfs/QmdcU6CRSNr6qYmyQAGjvFyZajEs9W1GH51rddCFw7S6p2',
-                    payer: poolCreator.publicKey,
-                    poolCreator: poolCreator.publicKey,
-                },
-                firstBuyParam: {
-                    buyer: poolCreator.publicKey,
-                    buyAmount: amountIn,
-                    minimumAmountOut: new BN(0),
-                    referralTokenAccount: null,
-                },
-            })
+        const createPoolWithFirstBuyTx = await dbcClient.pool.createPoolWithFirstBuy({
+            createPoolParam: {
+                baseMint: baseMint.publicKey,
+                config: config.publicKey,
+                name: 'TEST',
+                symbol: 'TEST',
+                uri: 'https://ipfs.io/ipfs/QmdcU6CRSNr6qYmyQAGjvFyZajEs9W1GH51rddCFw7S6p2',
+                payer: poolCreator.publicKey,
+                poolCreator: poolCreator.publicKey,
+            },
+            firstBuyParam: {
+                buyer: poolCreator.publicKey,
+                buyAmount: amountIn,
+                minimumAmountOut: new BN(0),
+                referralTokenAccount: null,
+            },
+        })
 
-        expect(swapBuyTx).toBeDefined()
+        createPoolWithFirstBuyTx.feePayer = poolCreator.publicKey
 
-        const bundledTx = new Transaction()
-        bundledTx.add(...createPoolTx.instructions)
-        if (swapBuyTx) {
-            bundledTx.add(...swapBuyTx.instructions)
-        }
-
-        bundledTx.feePayer = poolCreator.publicKey
-
-        await sendAndConfirmTransaction(connection, bundledTx, [
+        await sendAndConfirmTransaction(connection, createPoolWithFirstBuyTx, [
             poolCreator,
             baseMint,
         ])
@@ -289,34 +280,27 @@ describe('First Swap Tests', { timeout: 60000 }, () => {
     test('should charge min fee when first swap with pool creation (with SYSVAR)', async () => {
         const amountIn = new BN(1_000_000_000)
 
-        const { createPoolTx, swapBuyTx } =
-            await dbcClient.pool.createPoolWithFirstBuy({
-                createPoolParam: {
-                    baseMint: baseMint.publicKey,
-                    config: config.publicKey,
-                    name: 'TEST',
-                    symbol: 'TEST',
-                    uri: 'https://ipfs.io/ipfs/QmdcU6CRSNr6qYmyQAGjvFyZajEs9W1GH51rddCFw7S6p2',
-                    payer: poolCreator.publicKey,
-                    poolCreator: poolCreator.publicKey,
-                },
-                firstBuyParam: {
-                    buyer: poolCreator.publicKey,
-                    buyAmount: amountIn,
-                    minimumAmountOut: new BN(0),
-                    referralTokenAccount: null,
-                },
-            })
+        const createPoolWithFirstBuyTx = await dbcClient.pool.createPoolWithFirstBuy({
+            createPoolParam: {
+                baseMint: baseMint.publicKey,
+                config: config.publicKey,
+                name: 'TEST',
+                symbol: 'TEST',
+                uri: 'https://ipfs.io/ipfs/QmdcU6CRSNr6qYmyQAGjvFyZajEs9W1GH51rddCFw7S6p2',
+                payer: poolCreator.publicKey,
+                poolCreator: poolCreator.publicKey,
+            },
+            firstBuyParam: {
+                buyer: poolCreator.publicKey,
+                buyAmount: amountIn,
+                minimumAmountOut: new BN(0),
+                referralTokenAccount: null,
+            },
+        })
 
-        expect(swapBuyTx).toBeDefined()
+        createPoolWithFirstBuyTx.feePayer = poolCreator.publicKey
 
-        const bundledTx = new Transaction()
-        bundledTx.add(...createPoolTx.instructions)
-        bundledTx.add(...swapBuyTx!.instructions)
-
-        bundledTx.feePayer = poolCreator.publicKey
-
-        await sendAndConfirmTransaction(connection, bundledTx, [
+        await sendAndConfirmTransaction(connection, createPoolWithFirstBuyTx, [
             poolCreator,
             baseMint,
         ])
@@ -344,28 +328,32 @@ describe('First Swap Tests', { timeout: 60000 }, () => {
     test('should charge cliff fee when swap bundled WITHOUT SYSVAR', async () => {
         const amountIn = new BN(1_000_000_000)
 
-        const { createPoolTx, swapBuyTx } =
-            await dbcClient.pool.createPoolWithFirstBuy({
-                createPoolParam: {
-                    baseMint: baseMint.publicKey,
-                    config: config.publicKey,
-                    name: 'TEST',
-                    symbol: 'TEST',
-                    uri: 'https://ipfs.io/ipfs/QmdcU6CRSNr6qYmyQAGjvFyZajEs9W1GH51rddCFw7S6p2',
-                    payer: poolCreator.publicKey,
-                    poolCreator: poolCreator.publicKey,
-                },
-                firstBuyParam: {
-                    buyer: poolCreator.publicKey,
-                    buyAmount: amountIn,
-                    minimumAmountOut: new BN(0),
-                    referralTokenAccount: null,
-                },
-            })
+        const createPoolParam = {
+            baseMint: baseMint.publicKey,
+            config: config.publicKey,
+            name: 'TEST',
+            symbol: 'TEST',
+            uri: 'https://ipfs.io/ipfs/QmdcU6CRSNr6qYmyQAGjvFyZajEs9W1GH51rddCFw7S6p2',
+            payer: poolCreator.publicKey,
+            poolCreator: poolCreator.publicKey,
+        }
 
-        expect(swapBuyTx).toBeDefined()
+        const createPoolWithFirstBuyTx = await dbcClient.pool.createPoolWithFirstBuy({
+            createPoolParam,
+            firstBuyParam: {
+                buyer: poolCreator.publicKey,
+                buyAmount: amountIn,
+                minimumAmountOut: new BN(0),
+                referralTokenAccount: null,
+            },
+        })
 
-        const swapIxWithoutSysvar = swapBuyTx!.instructions.map((ix) => {
+        const createOnlyPoolTx = await dbcClient.pool.createPool(createPoolParam)
+        const createPoolIxCount = createOnlyPoolTx.instructions.length
+        const createPoolIxs = createPoolWithFirstBuyTx.instructions.slice(0, createPoolIxCount)
+        const swapIxs = createPoolWithFirstBuyTx.instructions.slice(createPoolIxCount)
+
+        const swapIxWithoutSysvar = swapIxs.map((ix) => {
             // remove SYSVAR_INSTRUCTIONS_PUBKEY from keys if present
             const filteredKeys = ix.keys.filter(
                 (key) => !key.pubkey.equals(SYSVAR_INSTRUCTIONS_PUBKEY)
@@ -376,9 +364,9 @@ describe('First Swap Tests', { timeout: 60000 }, () => {
             }
         })
 
-        // combine into single transaction without SYSVAR
+        // combine into single transaction without SYSVAR on swap instructions
         const bundledTx = new Transaction()
-        bundledTx.add(...createPoolTx.instructions)
+        bundledTx.add(...createPoolIxs)
         swapIxWithoutSysvar.forEach((ix) =>
             bundledTx.add({
                 programId: ix.programId,
@@ -419,34 +407,27 @@ describe('First Swap Tests', { timeout: 60000 }, () => {
     test('second swap after bundled first swap should charge cliff fee', async () => {
         const amountIn = new BN(1_000_000_000)
 
-        const { createPoolTx, swapBuyTx } =
-            await dbcClient.pool.createPoolWithFirstBuy({
-                createPoolParam: {
-                    baseMint: baseMint.publicKey,
-                    config: config.publicKey,
-                    name: 'TEST',
-                    symbol: 'TEST',
-                    uri: 'https://ipfs.io/ipfs/QmdcU6CRSNr6qYmyQAGjvFyZajEs9W1GH51rddCFw7S6p2',
-                    payer: poolCreator.publicKey,
-                    poolCreator: poolCreator.publicKey,
-                },
-                firstBuyParam: {
-                    buyer: poolCreator.publicKey,
-                    buyAmount: amountIn,
-                    minimumAmountOut: new BN(0),
-                    referralTokenAccount: null,
-                },
-            })
+        const createPoolWithFirstBuyTx = await dbcClient.pool.createPoolWithFirstBuy({
+            createPoolParam: {
+                baseMint: baseMint.publicKey,
+                config: config.publicKey,
+                name: 'TEST',
+                symbol: 'TEST',
+                uri: 'https://ipfs.io/ipfs/QmdcU6CRSNr6qYmyQAGjvFyZajEs9W1GH51rddCFw7S6p2',
+                payer: poolCreator.publicKey,
+                poolCreator: poolCreator.publicKey,
+            },
+            firstBuyParam: {
+                buyer: poolCreator.publicKey,
+                buyAmount: amountIn,
+                minimumAmountOut: new BN(0),
+                referralTokenAccount: null,
+            },
+        })
 
-        expect(swapBuyTx).toBeDefined()
+        createPoolWithFirstBuyTx.feePayer = poolCreator.publicKey
 
-        const bundledTx = new Transaction()
-        bundledTx.add(...createPoolTx.instructions)
-        bundledTx.add(...swapBuyTx!.instructions)
-
-        bundledTx.feePayer = poolCreator.publicKey
-
-        await sendAndConfirmTransaction(connection, bundledTx, [
+        await sendAndConfirmTransaction(connection, createPoolWithFirstBuyTx, [
             poolCreator,
             baseMint,
         ])
@@ -523,7 +504,7 @@ describe('First Swap Tests', { timeout: 60000 }, () => {
             newConfig.publicKey
         )
 
-        const { createConfigTx, createPoolTx, swapBuyTx } =
+        const { createConfigTx, createPoolWithFirstBuyTx } =
             await dbcClient.pool.createConfigAndPoolWithFirstBuy({
                 config: newConfig.publicKey,
                 feeClaimer: partner.publicKey,
@@ -547,8 +528,7 @@ describe('First Swap Tests', { timeout: 60000 }, () => {
             })
 
         expect(createConfigTx).toBeDefined()
-        expect(createPoolTx).toBeDefined()
-        expect(swapBuyTx).toBeDefined()
+        expect(createPoolWithFirstBuyTx).toBeDefined()
 
         createConfigTx.feePayer = poolCreator.publicKey
 
@@ -557,15 +537,9 @@ describe('First Swap Tests', { timeout: 60000 }, () => {
             newConfig,
         ])
 
-        const bundledTx = new Transaction()
-        bundledTx.add(...createPoolTx.instructions)
-        if (swapBuyTx) {
-            bundledTx.add(...swapBuyTx.instructions)
-        }
+        createPoolWithFirstBuyTx.feePayer = poolCreator.publicKey
 
-        bundledTx.feePayer = poolCreator.publicKey
-
-        await sendAndConfirmTransaction(connection, bundledTx, [
+        await sendAndConfirmTransaction(connection, createPoolWithFirstBuyTx, [
             poolCreator,
             newBaseMint,
         ])

--- a/packages/dynamic-bonding-curve/tests/first_swap.test.ts
+++ b/packages/dynamic-bonding-curve/tests/first_swap.test.ts
@@ -162,23 +162,24 @@ describe('First Swap Tests', { timeout: 60000 }, () => {
     test('should charge min fee when using SDK createPoolWithFirstBuy (bundled tx)', async () => {
         const amountIn = new BN(1_000_000_000) // 1 SOL
 
-        const createPoolWithFirstBuyTx = await dbcClient.pool.createPoolWithFirstBuy({
-            createPoolParam: {
-                baseMint: baseMint.publicKey,
-                config: config.publicKey,
-                name: 'TEST',
-                symbol: 'TEST',
-                uri: 'https://ipfs.io/ipfs/QmdcU6CRSNr6qYmyQAGjvFyZajEs9W1GH51rddCFw7S6p2',
-                payer: poolCreator.publicKey,
-                poolCreator: poolCreator.publicKey,
-            },
-            firstBuyParam: {
-                buyer: poolCreator.publicKey,
-                buyAmount: amountIn,
-                minimumAmountOut: new BN(0),
-                referralTokenAccount: null,
-            },
-        })
+        const createPoolWithFirstBuyTx =
+            await dbcClient.pool.createPoolWithFirstBuy({
+                createPoolParam: {
+                    baseMint: baseMint.publicKey,
+                    config: config.publicKey,
+                    name: 'TEST',
+                    symbol: 'TEST',
+                    uri: 'https://ipfs.io/ipfs/QmdcU6CRSNr6qYmyQAGjvFyZajEs9W1GH51rddCFw7S6p2',
+                    payer: poolCreator.publicKey,
+                    poolCreator: poolCreator.publicKey,
+                },
+                firstBuyParam: {
+                    buyer: poolCreator.publicKey,
+                    buyAmount: amountIn,
+                    minimumAmountOut: new BN(0),
+                    referralTokenAccount: null,
+                },
+            })
 
         createPoolWithFirstBuyTx.feePayer = poolCreator.publicKey
 
@@ -280,23 +281,24 @@ describe('First Swap Tests', { timeout: 60000 }, () => {
     test('should charge min fee when first swap with pool creation (with SYSVAR)', async () => {
         const amountIn = new BN(1_000_000_000)
 
-        const createPoolWithFirstBuyTx = await dbcClient.pool.createPoolWithFirstBuy({
-            createPoolParam: {
-                baseMint: baseMint.publicKey,
-                config: config.publicKey,
-                name: 'TEST',
-                symbol: 'TEST',
-                uri: 'https://ipfs.io/ipfs/QmdcU6CRSNr6qYmyQAGjvFyZajEs9W1GH51rddCFw7S6p2',
-                payer: poolCreator.publicKey,
-                poolCreator: poolCreator.publicKey,
-            },
-            firstBuyParam: {
-                buyer: poolCreator.publicKey,
-                buyAmount: amountIn,
-                minimumAmountOut: new BN(0),
-                referralTokenAccount: null,
-            },
-        })
+        const createPoolWithFirstBuyTx =
+            await dbcClient.pool.createPoolWithFirstBuy({
+                createPoolParam: {
+                    baseMint: baseMint.publicKey,
+                    config: config.publicKey,
+                    name: 'TEST',
+                    symbol: 'TEST',
+                    uri: 'https://ipfs.io/ipfs/QmdcU6CRSNr6qYmyQAGjvFyZajEs9W1GH51rddCFw7S6p2',
+                    payer: poolCreator.publicKey,
+                    poolCreator: poolCreator.publicKey,
+                },
+                firstBuyParam: {
+                    buyer: poolCreator.publicKey,
+                    buyAmount: amountIn,
+                    minimumAmountOut: new BN(0),
+                    referralTokenAccount: null,
+                },
+            })
 
         createPoolWithFirstBuyTx.feePayer = poolCreator.publicKey
 
@@ -338,20 +340,26 @@ describe('First Swap Tests', { timeout: 60000 }, () => {
             poolCreator: poolCreator.publicKey,
         }
 
-        const createPoolWithFirstBuyTx = await dbcClient.pool.createPoolWithFirstBuy({
-            createPoolParam,
-            firstBuyParam: {
-                buyer: poolCreator.publicKey,
-                buyAmount: amountIn,
-                minimumAmountOut: new BN(0),
-                referralTokenAccount: null,
-            },
-        })
+        const createPoolWithFirstBuyTx =
+            await dbcClient.pool.createPoolWithFirstBuy({
+                createPoolParam,
+                firstBuyParam: {
+                    buyer: poolCreator.publicKey,
+                    buyAmount: amountIn,
+                    minimumAmountOut: new BN(0),
+                    referralTokenAccount: null,
+                },
+            })
 
-        const createOnlyPoolTx = await dbcClient.pool.createPool(createPoolParam)
+        const createOnlyPoolTx =
+            await dbcClient.pool.createPool(createPoolParam)
         const createPoolIxCount = createOnlyPoolTx.instructions.length
-        const createPoolIxs = createPoolWithFirstBuyTx.instructions.slice(0, createPoolIxCount)
-        const swapIxs = createPoolWithFirstBuyTx.instructions.slice(createPoolIxCount)
+        const createPoolIxs = createPoolWithFirstBuyTx.instructions.slice(
+            0,
+            createPoolIxCount
+        )
+        const swapIxs =
+            createPoolWithFirstBuyTx.instructions.slice(createPoolIxCount)
 
         const swapIxWithoutSysvar = swapIxs.map((ix) => {
             // remove SYSVAR_INSTRUCTIONS_PUBKEY from keys if present
@@ -407,23 +415,24 @@ describe('First Swap Tests', { timeout: 60000 }, () => {
     test('second swap after bundled first swap should charge cliff fee', async () => {
         const amountIn = new BN(1_000_000_000)
 
-        const createPoolWithFirstBuyTx = await dbcClient.pool.createPoolWithFirstBuy({
-            createPoolParam: {
-                baseMint: baseMint.publicKey,
-                config: config.publicKey,
-                name: 'TEST',
-                symbol: 'TEST',
-                uri: 'https://ipfs.io/ipfs/QmdcU6CRSNr6qYmyQAGjvFyZajEs9W1GH51rddCFw7S6p2',
-                payer: poolCreator.publicKey,
-                poolCreator: poolCreator.publicKey,
-            },
-            firstBuyParam: {
-                buyer: poolCreator.publicKey,
-                buyAmount: amountIn,
-                minimumAmountOut: new BN(0),
-                referralTokenAccount: null,
-            },
-        })
+        const createPoolWithFirstBuyTx =
+            await dbcClient.pool.createPoolWithFirstBuy({
+                createPoolParam: {
+                    baseMint: baseMint.publicKey,
+                    config: config.publicKey,
+                    name: 'TEST',
+                    symbol: 'TEST',
+                    uri: 'https://ipfs.io/ipfs/QmdcU6CRSNr6qYmyQAGjvFyZajEs9W1GH51rddCFw7S6p2',
+                    payer: poolCreator.publicKey,
+                    poolCreator: poolCreator.publicKey,
+                },
+                firstBuyParam: {
+                    buyer: poolCreator.publicKey,
+                    buyAmount: amountIn,
+                    minimumAmountOut: new BN(0),
+                    referralTokenAccount: null,
+                },
+            })
 
         createPoolWithFirstBuyTx.feePayer = poolCreator.publicKey
 

--- a/packages/dynamic-bonding-curve/tests/partner_creator_first_swap.test.ts
+++ b/packages/dynamic-bonding-curve/tests/partner_creator_first_swap.test.ts
@@ -1,0 +1,246 @@
+import {
+    Connection,
+    Keypair,
+    PublicKey,
+    sendAndConfirmTransaction,
+} from '@solana/web3.js'
+import { test, describe, beforeEach, expect } from 'vitest'
+import { fundSol } from './utils/common'
+import {
+    ActivationType,
+    BaseFeeMode,
+    buildCurveWithCustomSqrtPrices,
+    CollectFeeMode,
+    ConfigParameters,
+    createSqrtPrices,
+    DammV2BaseFeeMode,
+    DammV2DynamicFeeMode,
+    deriveDbcPoolAddress,
+    DynamicBondingCurveClient,
+    MigrationFeeOption,
+    MigrationOption,
+    TokenDecimal,
+    TokenType,
+    TokenUpdateAuthorityOption,
+} from '../src'
+import { BN } from 'bn.js'
+import { NATIVE_MINT } from '@solana/spl-token'
+
+const connection = new Connection('http://127.0.0.1:8899', 'confirmed')
+
+describe('Partner Creator First Swap Tests', { timeout: 60000 }, () => {
+    let partner: Keypair
+    let creator: Keypair
+    let poolCreator: Keypair
+    let dbcClient: DynamicBondingCurveClient
+    let config: Keypair
+    let pool: PublicKey
+    let baseMint: Keypair
+    let curveConfig: ConfigParameters
+
+    beforeEach(async () => {
+        partner = Keypair.generate()
+        creator = Keypair.generate()
+        poolCreator = Keypair.generate()
+        config = Keypair.generate()
+        baseMint = Keypair.generate()
+
+        for (const account of [partner, creator, poolCreator]) {
+            await fundSol(connection, account.publicKey)
+        }
+
+        dbcClient = new DynamicBondingCurveClient(connection, 'confirmed')
+
+        const startingFeeBps = 9000
+        const endingFeeBps = 120
+        const numberOfPeriod = 60
+        const totalDuration = 60
+
+        const customPrices = [0.000000001, 0.00000000105, 0.000000002, 0.000001]
+        const tokenBaseDecimal = TokenDecimal.SIX
+        const tokenQuoteDecimal = TokenDecimal.NINE
+        const sqrtPrices = createSqrtPrices(
+            customPrices,
+            tokenBaseDecimal,
+            tokenQuoteDecimal
+        )
+        const liquidityWeights = [2, 1, 1]
+
+        curveConfig = buildCurveWithCustomSqrtPrices({
+            token: {
+                tokenType: TokenType.SPL,
+                tokenBaseDecimal: tokenBaseDecimal,
+                tokenQuoteDecimal: tokenQuoteDecimal,
+                tokenUpdateAuthority:
+                    TokenUpdateAuthorityOption.PartnerUpdateAuthority,
+                totalTokenSupply: 1_000_000_000,
+                leftover: 1000,
+            },
+            fee: {
+                baseFeeParams: {
+                    baseFeeMode: BaseFeeMode.FeeSchedulerLinear,
+                    feeSchedulerParam: {
+                        startingFeeBps,
+                        endingFeeBps,
+                        numberOfPeriod,
+                        totalDuration,
+                    },
+                },
+                dynamicFeeEnabled: false,
+                collectFeeMode: CollectFeeMode.QuoteToken,
+                creatorTradingFeePercentage: 0,
+                poolCreationFee: 0,
+                enableFirstSwapWithMinFee: true,
+            },
+            migration: {
+                migrationOption: MigrationOption.MET_DAMM_V2,
+                migrationFeeOption: MigrationFeeOption.Customizable,
+                migrationFee: {
+                    feePercentage: 10,
+                    creatorFeePercentage: 50,
+                },
+                migratedPoolFee: {
+                    collectFeeMode: CollectFeeMode.QuoteToken,
+                    dynamicFee: DammV2DynamicFeeMode.Enabled,
+                    poolFeeBps: 120,
+                    baseFeeMode: DammV2BaseFeeMode.FeeTimeSchedulerLinear,
+                },
+            },
+            liquidityDistribution: {
+                partnerLiquidityPercentage: 0,
+                partnerPermanentLockedLiquidityPercentage: 100,
+                creatorLiquidityPercentage: 0,
+                creatorPermanentLockedLiquidityPercentage: 0,
+            },
+            lockedVesting: {
+                totalLockedVestingAmount: 0,
+                numberOfVestingPeriod: 0,
+                cliffUnlockAmount: 0,
+                totalVestingDuration: 0,
+                cliffDurationFromMigrationTime: 0,
+            },
+            activationType: ActivationType.Timestamp,
+            sqrtPrices,
+            liquidityWeights,
+        })
+
+        const createConfigTx = await dbcClient.partner.createConfig({
+            config: config.publicKey,
+            feeClaimer: partner.publicKey,
+            leftoverReceiver: partner.publicKey,
+            payer: partner.publicKey,
+            quoteMint: NATIVE_MINT,
+            ...curveConfig,
+        })
+        createConfigTx.feePayer = partner.publicKey
+        await sendAndConfirmTransaction(connection, createConfigTx, [
+            partner,
+            config,
+        ])
+
+        pool = deriveDbcPoolAddress(
+            NATIVE_MINT,
+            baseMint.publicKey,
+            config.publicKey
+        )
+    })
+
+    test('bundles createPool + partnerBuy + creatorBuy into one transaction', async () => {
+        const partnerAmountIn = new BN(1_000_000_000)
+        const creatorAmountIn = new BN(500_000_000)
+
+        const createPoolParam = {
+            baseMint: baseMint.publicKey,
+            config: config.publicKey,
+            name: 'TEST',
+            symbol: 'TEST',
+            uri: 'https://ipfs.io/ipfs/QmdcU6CRSNr6qYmyQAGjvFyZajEs9W1GH51rddCFw7S6p2',
+            payer: poolCreator.publicKey,
+            poolCreator: poolCreator.publicKey,
+        }
+
+        const createOnlyPoolTx = await dbcClient.pool.createPool(createPoolParam)
+        const bundledTx =
+            await dbcClient.pool.createPoolWithPartnerAndCreatorFirstBuy({
+                createPoolParam,
+                partnerFirstBuyParam: {
+                    partner: partner.publicKey,
+                    receiver: partner.publicKey,
+                    buyAmount: partnerAmountIn,
+                    minimumAmountOut: new BN(0),
+                    referralTokenAccount: null,
+                },
+                creatorFirstBuyParam: {
+                    // Use same signer as partner to keep bundled legacy tx within size limit.
+                    creator: partner.publicKey,
+                    receiver: partner.publicKey,
+                    buyAmount: creatorAmountIn,
+                    minimumAmountOut: new BN(0),
+                    referralTokenAccount: null,
+                },
+            })
+
+        expect(bundledTx.instructions.length).toBeGreaterThan(
+            createOnlyPoolTx.instructions.length
+        )
+
+        bundledTx.feePayer = poolCreator.publicKey
+        await sendAndConfirmTransaction(connection, bundledTx, [
+            poolCreator,
+            baseMint,
+            partner,
+        ])
+
+        const poolState = await dbcClient.state.getPool(pool)
+        expect(poolState).not.toBeNull()
+        const totalTradingFee = poolState!.metrics.totalProtocolQuoteFee.add(
+            poolState!.metrics.totalTradingQuoteFee
+        )
+        expect(totalTradingFee.gt(new BN(0))).toBe(true)
+    })
+
+    test('bundles createPool + partnerBuy only when creator buy is omitted', async () => {
+        const partnerAmountIn = new BN(1_000_000_000)
+
+        const createPoolParam = {
+            baseMint: baseMint.publicKey,
+            config: config.publicKey,
+            name: 'TEST',
+            symbol: 'TEST',
+            uri: 'https://ipfs.io/ipfs/QmdcU6CRSNr6qYmyQAGjvFyZajEs9W1GH51rddCFw7S6p2',
+            payer: poolCreator.publicKey,
+            poolCreator: poolCreator.publicKey,
+        }
+
+        const createOnlyPoolTx = await dbcClient.pool.createPool(createPoolParam)
+        const bundledTx =
+            await dbcClient.pool.createPoolWithPartnerAndCreatorFirstBuy({
+                createPoolParam,
+                partnerFirstBuyParam: {
+                    partner: partner.publicKey,
+                    receiver: partner.publicKey,
+                    buyAmount: partnerAmountIn,
+                    minimumAmountOut: new BN(0),
+                    referralTokenAccount: null,
+                },
+            })
+
+        expect(bundledTx.instructions.length).toBeGreaterThan(
+            createOnlyPoolTx.instructions.length
+        )
+
+        bundledTx.feePayer = poolCreator.publicKey
+        await sendAndConfirmTransaction(connection, bundledTx, [
+            poolCreator,
+            baseMint,
+            partner,
+        ])
+
+        const poolState = await dbcClient.state.getPool(pool)
+        expect(poolState).not.toBeNull()
+        const totalTradingFee = poolState!.metrics.totalProtocolQuoteFee.add(
+            poolState!.metrics.totalTradingQuoteFee
+        )
+        expect(totalTradingFee.gt(new BN(0))).toBe(true)
+    })
+})

--- a/packages/dynamic-bonding-curve/tests/partner_creator_first_swap.test.ts
+++ b/packages/dynamic-bonding-curve/tests/partner_creator_first_swap.test.ts
@@ -159,7 +159,8 @@ describe('Partner Creator First Swap Tests', { timeout: 60000 }, () => {
             poolCreator: poolCreator.publicKey,
         }
 
-        const createOnlyPoolTx = await dbcClient.pool.createPool(createPoolParam)
+        const createOnlyPoolTx =
+            await dbcClient.pool.createPool(createPoolParam)
         const bundledTx =
             await dbcClient.pool.createPoolWithPartnerAndCreatorFirstBuy({
                 createPoolParam,
@@ -212,7 +213,8 @@ describe('Partner Creator First Swap Tests', { timeout: 60000 }, () => {
             poolCreator: poolCreator.publicKey,
         }
 
-        const createOnlyPoolTx = await dbcClient.pool.createPool(createPoolParam)
+        const createOnlyPoolTx =
+            await dbcClient.pool.createPool(createPoolParam)
         const bundledTx =
             await dbcClient.pool.createPoolWithPartnerAndCreatorFirstBuy({
                 createPoolParam,


### PR DESCRIPTION
## Changes

- Fixed `getPoolBaseTokenCurveProgress` function to correctly calculate the progress of the base token curve using `getBaseTokenForSwap` function
- `createConfigAndPoolWithFirstBuy` functions now return `createConfigTx` and `createPoolWithFirstBuyTx` as separate `Transaction` instead of an object containing 3 separate `Transaction`s
- `createPoolWithFirstBuy` functions now return a `Transaction` instead of an object containing the new config transaction and pool transaction
- `createPoolWithPartnerAndCreatorFirstBuy` functions now return a `Transaction` instead of an object containing the new config transaction and pool transaction