### PR TITLE
[fix]: getMigratedPoolMarketCapFeeSchedulerParams

### DIFF
--- a/packages/dynamic-bonding-curve/CHANGELOG.md
+++ b/packages/dynamic-bonding-curve/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Dynamic Bonding Curve SDK will be documented in this file.
 
+## [1.5.6] - 2026-03-24
+
+### Changed
+
+- Updated `getMigratedPoolMarketCapFeeSchedulerParams` function to use `startingMarketCap` and `endingMarketCap` instead of `sqrtPriceStepBps`
+
 ## [1.5.6] - 2026-03-12
 
 ### Added

--- a/packages/dynamic-bonding-curve/docs.md
+++ b/packages/dynamic-bonding-curve/docs.md
@@ -723,7 +723,8 @@ interface BuildCurveParams {
                 // Configure for market cap-based fee scheduling
                 endingBaseFeeBps: number // The ending base fee in basis points (must be < bonding curve's endingFeeBps)
                 numberOfPeriod: number // The number of periods
-                sqrtPriceStepBps: number // The square root price step in basis points
+                startingMarketCap: number // Initial market cap used as scheduler start reference
+                endingMarketCap: number // Target market cap where scheduler should be fully exhausted
                 schedulerExpirationDuration: number // The scheduler expiration duration in seconds
             }
         }
@@ -888,7 +889,8 @@ const curveConfigWithScheduler = buildCurve({
             marketCapFeeSchedulerParams: {
                 endingBaseFeeBps: 25, // Must be less than bonding curve's endingFeeBps (100)
                 numberOfPeriod: 100,
-                sqrtPriceStepBps: 10,
+                startingMarketCap: 20_000,
+                endingMarketCap: 20_000_000,
                 schedulerExpirationDuration: 1000000,
             },
         },
@@ -949,6 +951,8 @@ const transaction = await client.partner.createConfig({
 - When using `marketCapFeeSchedulerParams`:
     - `baseFeeMode` must be `DammV2BaseFeeMode.FeeMarketCapSchedulerLinear` (3) or `FeeMarketCapSchedulerExponential` (4).
     - `endingBaseFeeBps` must be strictly less than the bonding curve's `baseFeeParams.feeSchedulerParam.endingFeeBps`.
+    - `startingMarketCap` and `endingMarketCap` are required, and `endingMarketCap` must be greater than `startingMarketCap`.
+    - The SDK derives on-chain `sqrtPriceStepBps` from `startingMarketCap`, `endingMarketCap`, and `numberOfPeriod`.
     - `poolFeeBps` must be greater than 0.
 - If `migratedPoolFee.collectFeeMode = MigratedCollectFeeMode.Compounding` (2), `compoundingFeeBps` must be `> 0` and `<= 10_000`; otherwise `compoundingFeeBps` must be `0`.
 - For DAMM V1 migration, all `migratedPoolFee` parameters are ignored and defaults are used.

--- a/packages/dynamic-bonding-curve/package.json
+++ b/packages/dynamic-bonding-curve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteora-ag/dynamic-bonding-curve-sdk",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "source": "src/index.ts",

--- a/packages/dynamic-bonding-curve/src/helpers/common.ts
+++ b/packages/dynamic-bonding-curve/src/helpers/common.ts
@@ -1173,13 +1173,44 @@ export function getStartingBaseFeeBpsFromBaseFeeParams(
 }
 
 /**
+ * Computes the sqrtPriceStepBps needed so that the fee schedule is fully
+ * exhausted when spot price reaches a given multiple of the initial price.
+ * @param priceMultiple - Target spot-price multiple (e.g. 1000 for 1000x)
+ * @param numberOfPeriod - Number of fee reduction periods
+ * @returns The sqrtPriceStepBps value to use on-chain
+ */
+export function computeSqrtPriceStepBps(
+    priceMultiple: number,
+    numberOfPeriod: number
+): number {
+    if (priceMultiple <= 1) {
+        throw new Error('priceMultiple must be greater than 1')
+    }
+    if (numberOfPeriod <= 0) {
+        throw new Error('numberOfPeriod must be greater than 0')
+    }
+    const sqrtPriceStepBps = Math.floor(
+        ((Math.sqrt(priceMultiple) - 1) * MAX_BASIS_POINT) / numberOfPeriod
+    )
+    if (sqrtPriceStepBps <= 0) {
+        throw new Error(
+            'Computed sqrtPriceStepBps is 0 — increase priceMultiple or decrease numberOfPeriod'
+        )
+    }
+    return sqrtPriceStepBps
+}
+
+/**
  * Get the migrated pool market cap fee scheduler parameters
- * @param startingBaseFeeBps - The starting base fee in basis points
- * @param endingBaseFeeBps - The ending base fee in basis points
- * @param dammV2BaseFeeMode - The DAMM V2 base fee mode
- * @param numberOfPeriod - The number of periods
- * @param sqrtPriceStepBps - The sqrt price step in basis points
- * @param schedulerExpirationDuration - The scheduler expiration duration
+ * Derives sqrtPriceStepBps from starting/ending market cap so the fee schedule is
+ * fully exhausted when the token grows from startingMarketCap to endingMarketCap.
+ * @param startingBaseFeeBps - Starting (max) fee in basis points
+ * @param endingBaseFeeBps - Ending (min) fee in basis points
+ * @param baseFeeMode - Linear or exponential decay
+ * @param numberOfPeriod - Number of fee reduction periods
+ * @param startingMarketCap - Initial market cap (e.g. 20_000 for $20k)
+ * @param endingMarketCap - Target market cap (e.g. 20_000_000 for $20M)
+ * @param schedulerExpirationDuration - Seconds after which the schedule expires to the ending fee regardless of price
  * @returns The migrated pool market cap fee scheduler parameters
  */
 export function getMigratedPoolMarketCapFeeSchedulerParams(
@@ -1187,7 +1218,8 @@ export function getMigratedPoolMarketCapFeeSchedulerParams(
     endingBaseFeeBps: number,
     dammV2BaseFeeMode: DammV2BaseFeeMode,
     numberOfPeriod: number,
-    sqrtPriceStepBps: number,
+    startingMarketCap: number,
+    endingMarketCap: number,
     schedulerExpirationDuration: number
 ): MigratedPoolMarketCapFeeSchedulerParameters {
     if (
@@ -1221,15 +1253,15 @@ export function getMigratedPoolMarketCapFeeSchedulerParams(
         )
     }
 
-    if (
-        numberOfPeriod == 0 ||
-        sqrtPriceStepBps == 0 ||
-        schedulerExpirationDuration == 0
-    ) {
-        throw new Error(
-            'numberOfPeriod, sqrtPriceStepBps, and schedulerExpirationDuration must be greater than zero'
-        )
+    if (schedulerExpirationDuration == 0) {
+        throw new Error('schedulerExpirationDuration must be greater than zero')
     }
+
+    const priceMultiple = endingMarketCap / startingMarketCap
+    const sqrtPriceStepBps = computeSqrtPriceStepBps(
+        priceMultiple,
+        numberOfPeriod
+    )
 
     const maxBaseFeeNumerator = bpsToFeeNumerator(startingBaseFeeBps)
     const minBaseFeeNumerator = bpsToFeeNumerator(endingBaseFeeBps)
@@ -1242,16 +1274,10 @@ export function getMigratedPoolMarketCapFeeSchedulerParams(
     } else if (
         dammV2BaseFeeMode === DammV2BaseFeeMode.FeeMarketCapSchedulerExponential
     ) {
-        const ratio = new Decimal(minBaseFeeNumerator.toString()).div(
-            new Decimal(maxBaseFeeNumerator.toString())
-        )
-        const decayBase = ratio.pow(new Decimal(1).div(numberOfPeriod))
-        reductionFactor = new BN(
-            new Decimal(MAX_BASIS_POINT)
-                .mul(new Decimal(1).sub(decayBase))
-                .floor()
-                .toFixed()
-        )
+        const ratio =
+            minBaseFeeNumerator.toNumber() / maxBaseFeeNumerator.toNumber()
+        const decayBase = Math.pow(ratio, 1 / numberOfPeriod)
+        reductionFactor = new BN(MAX_BASIS_POINT * (1 - decayBase))
     }
 
     return {
@@ -1711,7 +1737,8 @@ export function getMigratedPoolFeeParams(
                 migratedPoolFee.marketCapFeeSchedulerParams.endingBaseFeeBps,
                 baseFeeMode,
                 migratedPoolFee.marketCapFeeSchedulerParams.numberOfPeriod,
-                migratedPoolFee.marketCapFeeSchedulerParams.sqrtPriceStepBps,
+                migratedPoolFee.marketCapFeeSchedulerParams.startingMarketCap,
+                migratedPoolFee.marketCapFeeSchedulerParams.endingMarketCap,
                 migratedPoolFee.marketCapFeeSchedulerParams
                     .schedulerExpirationDuration
             )

--- a/packages/dynamic-bonding-curve/src/helpers/common.ts
+++ b/packages/dynamic-bonding-curve/src/helpers/common.ts
@@ -1247,6 +1247,12 @@ export function getMigratedPoolMarketCapFeeSchedulerParams(
         )
     }
 
+    if (endingMarketCap <= startingMarketCap) {
+        throw new Error(
+            `endingMarketCap (${endingMarketCap}) must be greater than startingMarketCap (${startingMarketCap})`
+        )
+    }
+
     if (startingBaseFeeBps > poolMaxFeeBps) {
         throw new Error(
             `startingBaseFeeBps (${startingBaseFeeBps} bps) exceeds maximum allowed value of ${poolMaxFeeBps} bps`

--- a/packages/dynamic-bonding-curve/src/types.ts
+++ b/packages/dynamic-bonding-curve/src/types.ts
@@ -279,7 +279,8 @@ export type MigratedPoolFeeConfig = {
 export type MigratedPoolMarketCapFeeSchedulerParams = {
     endingBaseFeeBps: number
     numberOfPeriod: number
-    sqrtPriceStepBps: number
+    startingMarketCap: number
+    endingMarketCap: number
     schedulerExpirationDuration: number
 }
 

--- a/packages/dynamic-bonding-curve/tests/buildCurve.test.ts
+++ b/packages/dynamic-bonding-curve/tests/buildCurve.test.ts
@@ -108,7 +108,8 @@ describe('getMigratedPoolFeeParams Unit Tests', () => {
             marketCapFeeSchedulerParams: {
                 endingBaseFeeBps: 50,
                 numberOfPeriod: 10,
-                sqrtPriceStepBps: 100,
+                startingMarketCap: 20000,
+                endingMarketCap: 20000000,
                 schedulerExpirationDuration: 86400,
             },
         }
@@ -135,9 +136,6 @@ describe('getMigratedPoolFeeParams Unit Tests', () => {
             result.migratedPoolMarketCapFeeSchedulerParams.numberOfPeriod
         ).toBe(10)
         expect(
-            result.migratedPoolMarketCapFeeSchedulerParams.sqrtPriceStepBps
-        ).toBe(100)
-        expect(
             result.migratedPoolMarketCapFeeSchedulerParams
                 .schedulerExpirationDuration
         ).toBe(86400)
@@ -157,7 +155,8 @@ describe('getMigratedPoolFeeParams Unit Tests', () => {
             marketCapFeeSchedulerParams: {
                 endingBaseFeeBps: 100,
                 numberOfPeriod: 10,
-                sqrtPriceStepBps: 100,
+                startingMarketCap: 20000,
+                endingMarketCap: 20000000,
                 schedulerExpirationDuration: 86400,
             },
         }
@@ -684,7 +683,8 @@ describe('Migration Fee Option Tests', () => {
                         marketCapFeeSchedulerParams: {
                             endingBaseFeeBps: 50,
                             numberOfPeriod: 10,
-                            sqrtPriceStepBps: 100,
+                            startingMarketCap: 20000,
+                            endingMarketCap: 20000000,
                             schedulerExpirationDuration: 86400,
                         },
                     },
@@ -705,10 +705,6 @@ describe('Migration Fee Option Tests', () => {
                 curveConfig.migratedPoolMarketCapFeeSchedulerParams
                     .numberOfPeriod
             ).toBe(10)
-            expect(
-                curveConfig.migratedPoolMarketCapFeeSchedulerParams
-                    .sqrtPriceStepBps
-            ).toBe(100)
             expect(
                 curveConfig.migratedPoolMarketCapFeeSchedulerParams
                     .schedulerExpirationDuration
@@ -752,7 +748,8 @@ describe('Migration Fee Option Tests', () => {
                         marketCapFeeSchedulerParams: {
                             endingBaseFeeBps: 50,
                             numberOfPeriod: 15,
-                            sqrtPriceStepBps: 200,
+                            startingMarketCap: 20000,
+                            endingMarketCap: 20000000,
                             schedulerExpirationDuration: 172800,
                         },
                     },
@@ -809,7 +806,8 @@ describe('Migration Fee Option Tests', () => {
                         marketCapFeeSchedulerParams: {
                             endingBaseFeeBps: 50,
                             numberOfPeriod: 5,
-                            sqrtPriceStepBps: 50,
+                            startingMarketCap: 20000,
+                            endingMarketCap: 20000000,
                             schedulerExpirationDuration: 43200,
                         },
                     },
@@ -851,7 +849,8 @@ describe('Migration Fee Option Tests', () => {
                         marketCapFeeSchedulerParams: {
                             endingBaseFeeBps: 100,
                             numberOfPeriod: 10,
-                            sqrtPriceStepBps: 100,
+                            startingMarketCap: 20000,
+                            endingMarketCap: 20000000,
                             schedulerExpirationDuration: 86400,
                         },
                     },


### PR DESCRIPTION
- Updated `getMigratedPoolMarketCapFeeSchedulerParams` function to use `startingMarketCap` and `endingMarketCap` instead of `sqrtPriceStepBps`