### PR TITLE
Add package support metadata

### DIFF
--- a/packages/dynamic-bonding-curve/package.json
+++ b/packages/dynamic-bonding-curve/package.json
@@ -11,6 +11,10 @@
     "url": "git+https://github.com/MeteoraAg/dynamic-bonding-curve-sdk.git",
     "directory": "packages/dynamic-bonding-curve"
   },
+  "homepage": "https://github.com/MeteoraAg/dynamic-bonding-curve-sdk/tree/main/packages/dynamic-bonding-curve#readme",
+  "bugs": {
+    "url": "https://github.com/MeteoraAg/dynamic-bonding-curve-sdk/issues"
+  },
   "keywords": [
     "meteora-ag",
     "dynamic-bonding-curve",


### PR DESCRIPTION
## Summary
- add `homepage` metadata for the dynamic bonding curve package README
- add `bugs.url` metadata pointing to the repository issue tracker
- leave runtime code, dependencies, exports, and package contents unchanged

## Verification
- `node` manifest assertion for package name/version/homepage/bugs
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json` from `packages/dynamic-bonding-curve`